### PR TITLE
fix: use every time same url authors

### DIFF
--- a/_includes/author_link.html
+++ b/_includes/author_link.html
@@ -6,17 +6,16 @@
     {% if existingAuthor.login == author %}
       {% if isFirstAuthor %}
         <span class="meta-author">
-          <i class="fa fa-fw fa-pencil"><span class="visually-hidden">{% translate global.author_by %}</span></i> 
+          <i class="fa fa-fw fa-pencil"><span class="visually-hidden">{% translate global.author_by %}</span></i>
           {% elsif isLastAuthor %}
-             {% translate global.and %} 
+             {% translate global.and %}
           {% else %}
              ,
           {% endif %}
-          <a class="author-link" href="{{ '/authors/:author' | prepend: site.baseurl | replace: '//', '/' | replace: ':author', author }}">{{ existingAuthor.title }}</a>
+          <a class="author-link" href="{{ '/authors/:author' | prepend: site.baseurl_root | replace: '//', '/' | replace: ':author', author }}">{{ existingAuthor.title }}</a>
       {% if isLastAuthor %}
         </span>
       {% endif %}
     {% endif %}
   {% endfor %}
 {% endfor %}
-


### PR DESCRIPTION
# Description

Utiliser toujours la même url pour la page authors. Car cela fait des erreurs dans Google

<img width="652" alt="capture d ecran 2017-12-26 a 14 15 38" src="https://user-images.githubusercontent.com/1083083/34357428-4f3c42f8-ea47-11e7-803b-63d728914e6e.png">
