### PR TITLE
chore(ci): exec algolia after deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ install:
     - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
 
 script:
-    - bundle exec rake
+    - bundle exec rake lint
+    - bundle exec rake test
 
 after_success:
     - ./bin/deploy-pr.sh
@@ -38,3 +39,4 @@ after_deploy:
     - aws configure set preview.cloudfront true
     - aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"
     - ./bin/notify-slack.sh
+    - bundle exec rake deploy


### PR DESCRIPTION
By the way, this is almost a bugfix, there is no reason to send data to algolia if it is not deployed