### PR TITLE
Color footer md content

### DIFF
--- a/_sass/includes/_footer.scss
+++ b/_sass/includes/_footer.scss
@@ -1,5 +1,5 @@
 .footer {
-  background: $dark-indigo;
+  background-image: $footer-background;
   color: lighten($brand-black, 50%);
   font-family: $font-family-footer-contact;
   font-size: 1.5rem;

--- a/_sass/includes/_md-content.scss
+++ b/_sass/includes/_md-content.scss
@@ -71,7 +71,6 @@
     padding-left: .5rem;
 
     &::before {
-      color: $butterscotch;
       content: '\2022';
       font-size: 2rem;
       padding-right: 1.1225em;
@@ -79,14 +78,6 @@
   }
 
   a {
-    background: linear-gradient(
-      to bottom,
-      $butterscotch 0%,
-      $butterscotch 100%
-    );
-    background-position: 0 100%;
-    background-repeat: repeat-x;
-    background-size: 3px 3px;
     color: $mine-shaft;
     font-weight: bold;
     padding-bottom: .3rem;
@@ -95,6 +86,7 @@
 
     &:hover {
       background-size: 3px 25px;
+      text-decoration: underline;
     }
   }
 }

--- a/_sass/settings/_variables.scss
+++ b/_sass/settings/_variables.scss
@@ -48,6 +48,7 @@ $charcoal-grey: #333541;
 $lightgrey-background: #f9f9f9;
 $article-icons: #a8a8a8;
 $card-border: #d8d8d8;
+$butterscotch: #f8bb4f;
 $separator-desktop-articles: #838383;
 $pale-grey: #f6f6f6;
 


### PR DESCRIPTION
- Changer le background du footer en dessous par un background-gradient classique
- Remettre les bullets du markdown des pages en noir
- Remettre les liens des articles sans soulignage, en soulignage au hover