### PR TITLE
fix the footer not sticking to the bottom problem

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@ layout: compress
         <div class="content" id="js-content">
             {{ content }}
         </div>
-        <div class="content">
+        <div class="search-content">
             <div class="posts" id="js-content-search">
             </div>
         </div>

--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -22,7 +22,10 @@ html {
 // Typography
 body {
   color: $brand-black;
+  display: flex;
+  flex-direction: column;
   font-family: $font-family-main;
+  min-height: 100vh;
   word-wrap: break-word;
 
   @media (max-width: $breakpoint-medium) {

--- a/_sass/includes/_footer.scss
+++ b/_sass/includes/_footer.scss
@@ -4,6 +4,7 @@
   font-family: $font-family-footer-contact;
   font-size: 1.5rem;
   font-weight: 400;
+  margin-top: auto;
   padding: 3rem 1.5rem 5rem;
   text-align: center;
   width: 100%;

--- a/_sass/layouts/_index.scss
+++ b/_sass/layouts/_index.scss
@@ -1,3 +1,13 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.home {
+  flex-grow: 1;
+}
+
 .article-container {
   background-color: $background-lightgrey;
   display: flex;

--- a/js/search.js
+++ b/js/search.js
@@ -29,7 +29,7 @@ layout: compress-js
   close.addEventListener("click", function(){
     search.className = 'header-bottom__headband--not-displayed';
     contentSearchId.style.display = 'none';
-    contentId.style.display = 'block';
+    contentId.style.display = 'flex';
   });
 
   function onQueryChange(e) {


### PR DESCRIPTION
le footer flottait sous le contenu lorsqu'il n'y en avait pas beaucoup où lors d'une recherche par exemple, le footer doit donc avoir un comportement sticky quand le contenu fait moins d'un écran et suivre le contenu quand il est plus grand qu'un écran. 

la modif js a été faite car le style display : "block" était fixé en js, ce qui désactivait les propriétés dépendantes d'un display: "flex".