### PR TITLE
fix: format Algolia date string to be JS compliant

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -58,7 +58,13 @@ layout: compress-js
 
         const url = baseurl + hit.url;
         const locale = lang === 'fr' ? 'fr-FR' : 'en-GB';
-        const hitDate = new Date(hit.date).toLocaleDateString(locale, { day: 'numeric', month: 'long', year: 'numeric' });
+
+        const formatAlgoliaDateString = (dateString) => {
+          const [date, hour, timezone] = dateString.split(' ');
+          return `${date}T${hour}${timezone}`;
+        };
+
+        const hitDate = new Date(formatAlgoliaDateString(hit.date)).toLocaleDateString(locale, { day: 'numeric', month: 'long', year: 'numeric' });
 
         return article + `
           <div class="article-container">


### PR DESCRIPTION
Fix issue #707

In fact, Algolia is not returning a date string format compatible with the JS `Date()` function.