### PR TITLE
doc(readme): update image path on readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Votre article doit être écrit en [markdown](https://guides.github.com/features
  Si vous avez besoin de mettre des images dans votre article il faut d'abord les ajouter dans le dossier suivant `assets/AAAA-MM-DD-titre/`, puis les insérer dans votre article.
 
 ```md
-![DESCRIPTION](/assets/AAAA-MM-DD-titre/MON IMAGE)
+![DESCRIPTION]({{ site.baseurl }}/assets/AAAA-MM-DD-titre/MON IMAGE)
 ```
 
 **4 - Demandez la publication**


### PR DESCRIPTION
* to avoid some errors when integrating some images for a blog article,
update the image path example into the README.
* the developer can now copy/paste the example without any error.

