### PR TITLE
feat: SEO: increase number of articles per page

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,7 @@ export const CATEGORIES = ['javascript', 'php', 'agile', 'architecture'] as cons
 export type CategoryEnum = (typeof CATEGORIES)[number];
 
 export const DEFAULT_LANGUAGE = LanguageEnum.FR;
-export const NUMBER_OF_ITEMS_PER_PAGE = 6;
+export const NUMBER_OF_ITEMS_PER_PAGE = 8;
 
 export const PATHS = {
   ROOT: '/',


### PR DESCRIPTION
SEO agency recommendation is to increase the number of articles per page to 18 in order for google to be able to crawl articles more easily.
But i'm afraid this might have a web perf impact.
So i'm increasing that number to 8 only for now.
