### PR TITLE
fix: bump lighthouse action version

### DIFF
--- a/.github/workflows/continuous-integration-and-deployment.yml
+++ b/.github/workflows/continuous-integration-and-deployment.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Audit URLs using Lighthouse
         id: lighthouse_audit
-        uses: treosh/lighthouse-ci-action@v9
+        uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
             ${{ env.ENV_URL }}/

--- a/.github/workflows/lighthouse-config.cjs
+++ b/.github/workflows/lighthouse-config.cjs
@@ -14,7 +14,7 @@ module.exports = {
   categories: {
     performance: ({
       auditRefs: [
-        { id: 'first-contentful-paint-3g', weight: 0 },
+        { id: 'first-contentful-paint', weight: 0 },
       ],
     }),
   },

--- a/.github/workflows/lighthouse-config.cjs
+++ b/.github/workflows/lighthouse-config.cjs
@@ -9,7 +9,7 @@ module.exports = {
     skipAudits: ['uses-http2'],
   },
   audits: [
-    'metrics/first-contentful-paint-3g',
+    'metrics/first-contentful-paint',
   ],
   categories: {
     performance: ({


### PR DESCRIPTION
j'ai bump en version 12.

la métrique first-contentful-paint-3g n'existe plus https://github.com/GoogleChrome/lighthouse/pull/15252 https://github.com/GoogleChrome/lighthouse/issues/14905